### PR TITLE
DROTH_4127_4128 get env from context

### DIFF
--- a/velho-integration/lib/velho-integration-stack.ts
+++ b/velho-integration/lib/velho-integration-stack.ts
@@ -16,7 +16,9 @@ export class VelhoIntegrationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const ENV = 'dev'
+    const ENV: string | undefined = scope.node.tryGetContext('env')
+
+    if (!ENV) throw new Error('env not defined')
 
     const vpcId = StringParameter.valueFromLookup(this, `/${ENV}/vpcid`);
     const vpc = Vpc.fromLookup(this, vpcId, { vpcId });


### PR DESCRIPTION
Koitan hakea envin pipelinen kontekstista kovakoodatun devin sijaan, jotta voi laajentaa qa:lle.