### PR TITLE
DROTH-4141 add context to cdk synth and refactor objects

### DIFF
--- a/cicd/bin/cicd.ts
+++ b/cicd/bin/cicd.ts
@@ -11,17 +11,17 @@ export interface BranchConfig {
 
 const app = new cdk.App();
 
-const branchToContext: { [branch: string]: BranchConfig } = {
+const branchEnvMap: { [branch: string]: BranchConfig } = {
   "development": { env: "dev", account: "475079312496", region: "eu-west-1" }
 };
 
 const branch = app.node.tryGetContext('branch')
 
-if (!branch || !(branch in branchToContext)) {
+if (!branch || !(branch in branchEnvMap)) {
   throw new Error(`Branch name '${branch}' is not recognized.`);
 }
 
-new BatchCICDStack(app, `${branchToContext[branch].env}-BatchCICDStack`, {
-  branchEnvMap: branchToContext,
-  allowedBranches: Object.keys(branchToContext),
+new BatchCICDStack(app, `${branchEnvMap[branch].env}-BatchCICDStack`, {
+  branch,
+  branchConfig: branchEnvMap[branch],
 });

--- a/cicd/lib/cicd-stack.ts
+++ b/cicd/lib/cicd-stack.ts
@@ -7,83 +7,82 @@ import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as iam from 'aws-cdk-lib/aws-iam';
 
 interface BatchCICDStackProps extends StackProps {
-  branchEnvMap: { [branch: string]: BranchConfig };
-  allowedBranches: string[];
+  branch: string,
+  branchConfig: BranchConfig
 }
 
 export class BatchCICDStack extends Stack {
   constructor(scope: Construct, id: string, props: BatchCICDStackProps) {
     super(scope, id, props);
 
-    const { branchEnvMap, allowedBranches } = props;
+    const { branch, branchConfig } = props;
 
     const projects = ['velho-integration']
 
     projects.forEach((project) => {
-      this.createPipelineForProject(project, branchEnvMap, allowedBranches);
+      this.createPipelineForProject(project, branch, branchConfig);
     });
   }
 
-  private createPipelineForProject(project: string, branchEnvMap: { [branch: string]: BranchConfig }, allowedBranches: string[]) {
-    allowedBranches.forEach((branch) => {
-      const { env, account, region } = branchEnvMap[branch];
-      const sourceOutput = new codepipeline.Artifact();
+  private createPipelineForProject(project: string, branch: string, branchConfig: BranchConfig) {
 
-      const sourceAction = new codepipelineActions.GitHubSourceAction({
-        actionName: `${env}-${project}-source-action`,
-        owner: 'finnishtransportagency',
-        repo: 'digiroad-batch',
-        branch,
-        oauthToken: SecretValue.secretsManager('GITHUB_PAT'),
-        output: sourceOutput,
-      });
+    const { env, account, region } = branchConfig;
+    const sourceOutput = new codepipeline.Artifact();
 
-      const buildProject = new codebuild.PipelineProject(this, `${env}-${project}-build`, {
-        projectName: `${env}-${project}-build`,
-        environment: {
-          buildImage: codebuild.LinuxBuildImage.STANDARD_7_0,
+    const sourceAction = new codepipelineActions.GitHubSourceAction({
+      actionName: `${env}-${project}-source-action`,
+      owner: 'finnishtransportagency',
+      repo: 'digiroad-batch',
+      branch,
+      oauthToken: SecretValue.secretsManager('GITHUB_PAT'),
+      output: sourceOutput,
+    });
+
+    const buildProject = new codebuild.PipelineProject(this, `${env}-${project}-build`, {
+      projectName: `${env}-${project}-build`,
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.STANDARD_7_0,
+      },
+      buildSpec: codebuild.BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          install: {
+            commands: [
+              `cd ${project}`,
+              'npm install',
+              'npm install -g aws-cdk',
+            ],
+          },
+          build: {
+            commands: [
+              `cdk synth --context branch=${branch} --context env=${env} --context account=${account} --context region=${region}`,
+              `cdk deploy --require-approval never --context branch=${branch} --context env=${env} --context account=${account} --context region=${region}`,
+            ],
+          },
         },
-        buildSpec: codebuild.BuildSpec.fromObject({
-          version: '0.2',
-          phases: {
-            install: {
-              commands: [
-                `cd ${project}`,
-                'npm install',
-                'npm install -g aws-cdk',
-              ],
-            },
-            build: {
-              commands: [
-                'cdk synth',
-                `cdk deploy --require-approval never --context branch=${branch} --context env=${env} --context account=${account} --context region=${region}`,
-              ],
-            },
-          },
-        }),
-      });
+      }),
+    });
 
-      buildProject.role?.addManagedPolicy(iam.ManagedPolicy.fromManagedPolicyArn(this, 'cicdAdminPolicy', 'arn:aws:iam::aws:policy/AdministratorAccess'))
+    buildProject.role?.addManagedPolicy(iam.ManagedPolicy.fromManagedPolicyArn(this, 'cicdAdminPolicy', 'arn:aws:iam::aws:policy/AdministratorAccess'))
 
-      const buildAction = new codepipelineActions.CodeBuildAction({
-        actionName: `${env}-${project}-build-action`,
-        project: buildProject,
-        input: sourceOutput,
-      });
+    const buildAction = new codepipelineActions.CodeBuildAction({
+      actionName: `${env}-${project}-build-action`,
+      project: buildProject,
+      input: sourceOutput,
+    });
 
-      new codepipeline.Pipeline(this, `${env}-${project}-pipeline`, {
-        pipelineName: `${env}-${project}-pipeline`,
-        stages: [
-          {
-            stageName: 'Source',
-            actions: [sourceAction],
-          },
-          {
-            stageName: 'Build_and_Deploy',
-            actions: [buildAction],
-          },
-        ],
-      });
-    })
+    new codepipeline.Pipeline(this, `${env}-${project}-pipeline`, {
+      pipelineName: `${env}-${project}-pipeline`,
+      stages: [
+        {
+          stageName: 'Source',
+          actions: [sourceAction],
+        },
+        {
+          stageName: 'Build_and_Deploy',
+          actions: [buildAction],
+        },
+      ],
+    });
   }
 }


### PR DESCRIPTION
Lisätty context cdk synthiin, jotta integraatiokoodi ei kaadu, kun env haetaan contextista. Samalla refaktoroitu muutamaa kohtaa, jotka myöhemmin katsottuna tuntui turhan monimutkaisilta. Git näyttää enemmän muutoksia, kun oikeasti on, koska sisennyksiä meni uusiksi.