### PR TITLE
DROTH_4127_4128 unique result path for state machine error info

### DIFF
--- a/velho-integration/lib/velho-integration-stack.ts
+++ b/velho-integration/lib/velho-integration-stack.ts
@@ -107,7 +107,7 @@ export class VelhoIntegrationStack extends Stack {
         snsTask.next(passTask);
 
         const taskWithCatch = currentTask.addCatch(snsTask, {
-          resultPath: '$.error-info'
+          resultPath: `$.${ely}-${asset.asset_name}-error-info`
         });
 
         parallelAssets.branch(Chain.start(taskWithCatch));


### PR DESCRIPTION
Uniikki result path myös testiympäristöön. En saanut toistettua ongelmaa devillä, mutta ei tuo mitään rikkonutkaan.