### PR TITLE
DROTH_4127_4128 test null result path to fix input confict

### DIFF
--- a/velho-integration/lib/velho-integration-stack.ts
+++ b/velho-integration/lib/velho-integration-stack.ts
@@ -107,7 +107,7 @@ export class VelhoIntegrationStack extends Stack {
         snsTask.next(passTask);
 
         const taskWithCatch = currentTask.addCatch(snsTask, {
-          resultPath: `$.${ely}-${asset.asset_name}-error-info`
+          resultPath: null
         });
 
         parallelAssets.branch(Chain.start(taskWithCatch));


### PR DESCRIPTION
Ilmeisesti ongelma on, että state machine yrittää sisällyttää resultin seuraavan lambdan inputiin. Kokeilen, jos tämä auttaisi.