### PR TITLE
Droth 4130 velho integration for pavements for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Digiroad-batch
+
+Repository for digiroad batches.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Digiroad-batch

--- a/velho-integration/lib/velho-integration-stack.ts
+++ b/velho-integration/lib/velho-integration-stack.ts
@@ -32,7 +32,7 @@ export class VelhoIntegrationStack extends Stack {
       vpc,
       vpcSubnets,
       runtime: Runtime.NODEJS_20_X,
-      timeout: Duration.seconds(600),
+      timeout: Duration.seconds(900),
       memorySize: 1024,
       entry: './src/lambda/fetchAndProcess.ts',
       handler: 'handler',

--- a/velho-integration/lib/velho-integration-stack.ts
+++ b/velho-integration/lib/velho-integration-stack.ts
@@ -33,7 +33,7 @@ export class VelhoIntegrationStack extends Stack {
       vpcSubnets,
       runtime: Runtime.NODEJS_20_X,
       timeout: Duration.seconds(600),
-      memorySize: 256,
+      memorySize: 1024,
       entry: './src/lambda/fetchAndProcess.ts',
       handler: 'handler',
       bundling: {
@@ -74,8 +74,9 @@ export class VelhoIntegrationStack extends Stack {
     // states
     const ELYs = ["15", "13", "11", "10", "08", "05", "06", "01", "02"];
     const assets = [
-      { asset_name: "pedestrian_crossing", asset_type_id: 200, asset_type: "Point", path: "kohdepisteet-ja-valit/suojatiet" },
-      { asset_name: "lit_road", asset_type_id: 100, asset_type: "Linear", path: "varusteet/valaistukset" },
+      { asset_name: "lit_road", asset_type_id: 100, asset_type: "Linear", paths: ["varusteet/valaistukset"] },
+      { asset_name: "paved_road", asset_type_id: 110, asset_type: "Linear", paths: ["paallyste-ja-pintarakenne/sitomattomat-pintarakenteet", "paallyste-ja-pintarakenne/ladottavat-pintarakenteet", "paallyste-ja-pintarakenne/sidotut-paallysrakenteet", "paallyste-ja-pintarakenne/pintaukset", "paallyste-ja-pintarakenne/muut-pintarakenteet"] },
+      { asset_name: "pedestrian_crossing", asset_type_id: 200, asset_type: "Point", paths: ["kohdepisteet-ja-valit/suojatiet"] },
     ];
 
     let chain: Chain | undefined = undefined;
@@ -91,7 +92,7 @@ export class VelhoIntegrationStack extends Stack {
             asset_name: asset.asset_name,
             asset_type_id: asset.asset_type_id,
             asset_type: asset.asset_type,
-            path: asset.path,
+            paths: asset.paths,
           }),
         });
 

--- a/velho-integration/package.json
+++ b/velho-integration/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "build": "esbuild bin/velho-integration.ts --outdir=.build --platform=node",
+    "compile": "tsc",
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk"

--- a/velho-integration/src/lambda/assetHandler.ts
+++ b/velho-integration/src/lambda/assetHandler.ts
@@ -76,6 +76,13 @@ interface Kohdeluokka {
     }
 }
 
+export interface DiffResponce {
+    added: VelhoAsset[],
+    expired:  DbAsset[],
+    updated: VelhoAsset[],
+    notTouched:  DbAsset[]
+}
+
 export abstract class AssetHandler {
 
     abstract getRoadLinks(srcData: VelhoAsset[], vkmApiKey: string): Promise<AssetWithLinkData[]>;

--- a/velho-integration/src/lambda/assetHandler.ts
+++ b/velho-integration/src/lambda/assetHandler.ts
@@ -76,13 +76,6 @@ interface Kohdeluokka {
     }
 }
 
-export interface DiffResponce {
-    added: VelhoAsset[],
-    expired:  DbAsset[],
-    updated: VelhoAsset[],
-    notTouched:  DbAsset[]
-}
-
 export abstract class AssetHandler {
 
     abstract getRoadLinks(srcData: VelhoAsset[], vkmApiKey: string): Promise<AssetWithLinkData[]>;

--- a/velho-integration/src/lambda/assetHandler.ts
+++ b/velho-integration/src/lambda/assetHandler.ts
@@ -56,14 +56,14 @@ export interface VelhoLinearAsset extends VelhoAsset {
 }
 
 export interface AssetWithLinkData {
-        asset: VelhoAsset;
-        linkData: Array<{
-            linkId: string;
-            mValue: number;
-            mValueEnd?: number;
-            municipalityCode: number;
-            sideCode?: number;
-        }>;
+    asset: VelhoAsset;
+    linkData: Array<{
+        linkId: string;
+        mValue: number;
+        mValueEnd?: number;
+        municipalityCode: number;
+        sideCode?: number;
+    }>;
 }
 
 interface Kohdeluokka {
@@ -244,6 +244,6 @@ export abstract class AssetHandler {
 
     abstract saveNewAssets(asset_type_id: number, newAssets: AssetWithLinkData[]): Promise<void>;
 
-    abstract updateAssets(assetsToUpdate: AssetWithLinkData[]): Promise<void>;
+    abstract updateAssets(asset_type_id: number, assetsToUpdate: AssetWithLinkData[]): Promise<void>;
 
 }

--- a/velho-integration/src/lambda/enumerations.ts
+++ b/velho-integration/src/lambda/enumerations.ts
@@ -1,0 +1,36 @@
+// Road address track
+export enum Track {
+    Combined = 0,
+    RightSide = 1,
+    LeftSide = 2,
+    Unknown = 99
+}
+
+// VelhoRoadSide describes the location in relation to the road and it's road address's direction of growth
+export enum VelhoRoadSide {
+    Right = 1,      // p01
+    Left = 2,       // p02
+    Between = 3,    // p03
+    Across = 6      // p06
+}
+
+// VelhoValidityDirection describes the validity direction in relation to lane's traffic direction
+export enum VelhoValidityDirection {
+    TowardsTrafficDirection = 1,      // liivasu01 
+    AgainstTrafficDirection = 2,       // liivasu02 
+    LengthwiseTrafficDirection = 3,    // liivasu03 
+}
+
+export enum ValidityDirectionRoadAddress {
+    TowardsRoadAddressGrowth = 1,      
+    AgainstRoadAddressGrowth = 2,       
+    LengthwiseRoadAddressGrowth = 3,    
+}
+
+// SideCode describes the location or validity direction in relation to RoadLink digitzing direction
+export enum SideCode {
+    BothDirections = 1,
+    TowardsDigitizing = 2,
+    AgainstDigitizing = 3,
+    Unknown = 99
+}

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -106,7 +106,7 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     
     console.log(`assets left untouched: ${notTouched.length}`)
     console.log(`assets to expire: ${expired.length}`)
-    //await assetHandler.expireAssets(expired)
+    await assetHandler.expireAssets(expired)
     console.log(`assets to add: ${added.length}`)
     const addedWithLinks = await assetHandler.getRoadLinks(added, vkmApiKey)
    
@@ -116,10 +116,8 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     console.log('road link data fetched')
     console.log('start saving')
     const addedWithDigiroadLinks = await assetHandler.filterRoadLinks(addedWithLinks)
-    
-    
     const updatedWithDigiroadLinks =await  assetHandler.filterRoadLinks(updatedWithLinks)
    
-    //await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
-   // await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
+    await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
+    await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
 }

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -108,12 +108,13 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     if (!ely2polku[ely]) throw new Error("no path found for ely")
     const srcData = await assetHandler.fetchSourceData(authToken, ely2polku[ely]) as VelhoAsset[]
     console.log(`fetched ${srcData.length} assets from velho`)
-    if (srcData.length === 0) return
+    const filteredSrc = assetHandler.filterUnnecessary(srcData)
+    if (filteredSrc.length === 0) return
     const municipalities = await fetchMunicipalities(ely)
     console.log(`municipalities to process: ${municipalities.join(',')}`)
     const currentData = await assetHandler.fetchDestData(asset_type_id, municipalities)
     console.log(`fetched ${currentData.length} assets from digiroad`)
-    const { added, expired, updated, notTouched } = assetHandler.calculateDiff(srcData, currentData)
+    const { added, expired, updated, notTouched } = assetHandler.calculateDiff(filteredSrc, currentData)
     console.log(`assets left untouched: ${notTouched.length}`)
     console.log(`assets to expire: ${expired.length}`)
     await assetHandler.expireAssets(expired)

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -84,11 +84,10 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     const vkmApiKey = await getVkmApiKey()
     if (!vkmApiKey) throw new Error("vkm api key is not defined")
     const authToken = await authenticate()
-    const srcData = await timer("fetchSource", async () => {
-        return await assetHandler.fetchSource(authToken, ely, paths)
-    })
+    const srcData = await assetHandler.fetchSource(authToken, ely, paths)
+  
     console.log(`fetched ${srcData.length} assets from velho`)
-    const filteredSrc = await timer("filterUnnecessary", async () => {
+    const filteredSrc = timer("filterUnnecessary", () => {
         return assetHandler.filterUnnecessary(srcData)
     })
     console.log(`fetched assets from velho filtered`)
@@ -98,9 +97,8 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     }
     const municipalities = await fetchMunicipalities(ely)
     console.log(`municipalities to process: ${municipalities.join(',')}`)
-    const currentData = await timer("fetchDestData", async () => {
-        return await assetHandler.fetchDestData(asset_type_id, municipalities)
-    })
+    const currentData = await assetHandler.fetchDestData(asset_type_id, municipalities)
+
     console.log(`fetched ${currentData.length} assets from digiroad`)
     const { added, expired, updated, notTouched }  = timer("calculateDiff", ()=> {
         return assetHandler.calculateDiff(filteredSrc, currentData)
@@ -110,22 +108,18 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     console.log(`assets to expire: ${expired.length}`)
     //await assetHandler.expireAssets(expired)
     console.log(`assets to add: ${added.length}`)
-    const addedWithLinks = await  timer("addedWithLinks", async () => {
-        return await assetHandler.getRoadLinks(added, vkmApiKey)
-    })
+    const addedWithLinks = await assetHandler.getRoadLinks(added, vkmApiKey)
+   
     console.log(`assets to update: ${updated.length}`)
-    const updatedWithLinks= await timer("updatedWithLinks", async () => {
-        return await assetHandler.getRoadLinks(updated, vkmApiKey)
-    })
+    const updatedWithLinks= await assetHandler.getRoadLinks(updated, vkmApiKey)
+  
     console.log('road link data fetched')
     console.log('start saving')
-    const addedWithDigiroadLinks = await timer("addedWithDigiroadLinks",  async () => {
-        return await assetHandler.filterRoadLinks(addedWithLinks)
-    })
+    const addedWithDigiroadLinks = await assetHandler.filterRoadLinks(addedWithLinks)
     
-    const updatedWithDigiroadLinks =await  timer("updatedWithDigiroadLinks ", async () => {
-        return await assetHandler.filterRoadLinks(updatedWithLinks)
-    })
+    
+    const updatedWithDigiroadLinks =await  assetHandler.filterRoadLinks(updatedWithLinks)
+   
     //await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
    // await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
 }

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -4,6 +4,7 @@ import { Agent, setGlobalDispatcher } from 'undici';
 import { PointAssetHandler } from "./pointAssetHandler";
 import { LinearAssetHandler } from "./linearAssetHandler";
 import { PavementHandler } from "./pavementHandler";
+import {timer} from "./utils";
 
 const agent = new Agent({
     connect: {
@@ -83,28 +84,48 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     const vkmApiKey = await getVkmApiKey()
     if (!vkmApiKey) throw new Error("vkm api key is not defined")
     const authToken = await authenticate()
-    const srcData = await assetHandler.fetchSource(authToken, ely, paths)
+    const srcData = await timer("fetchSource", async () => {
+        return await assetHandler.fetchSource(authToken, ely, paths)
+    })
     console.log(`fetched ${srcData.length} assets from velho`)
-    const filteredSrc = assetHandler.filterUnnecessary(srcData)
+    const filteredSrc = await timer("filterUnnecessary", async () => {
+        return assetHandler.filterUnnecessary(srcData)
+    })
+    console.log(`fetched assets from velho filtered`)
     if (filteredSrc.length === 0) {
         console.log('No assets to process after filtering.')
         return
     }
     const municipalities = await fetchMunicipalities(ely)
     console.log(`municipalities to process: ${municipalities.join(',')}`)
-    const currentData = await assetHandler.fetchDestData(asset_type_id, municipalities)
+    const currentData = await timer("fetchDestData", async () => {
+        return await assetHandler.fetchDestData(asset_type_id, municipalities)
+    })
     console.log(`fetched ${currentData.length} assets from digiroad`)
-    const { added, expired, updated, notTouched } = assetHandler.calculateDiff(filteredSrc, currentData)
+    const { added, expired, updated, notTouched }  = timer("calculateDiff", ()=> {
+        return assetHandler.calculateDiff(filteredSrc, currentData)
+    })
+    
     console.log(`assets left untouched: ${notTouched.length}`)
     console.log(`assets to expire: ${expired.length}`)
-    await assetHandler.expireAssets(expired)
+    //await assetHandler.expireAssets(expired)
     console.log(`assets to add: ${added.length}`)
-    const addedWithLinks = await assetHandler.getRoadLinks(added, vkmApiKey)
+    const addedWithLinks = await  timer("addedWithLinks", async () => {
+        return await assetHandler.getRoadLinks(added, vkmApiKey)
+    })
     console.log(`assets to update: ${updated.length}`)
-    const updatedWithLinks = await assetHandler.getRoadLinks(updated, vkmApiKey)
+    const updatedWithLinks= await timer("updatedWithLinks", async () => {
+        return await assetHandler.getRoadLinks(updated, vkmApiKey)
+    })
     console.log('road link data fetched')
-    const addedWithDigiroadLinks = await assetHandler.filterRoadLinks(addedWithLinks)
-    await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
-    const updatedWithDigiroadLinks = await assetHandler.filterRoadLinks(updatedWithLinks)
-    await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
+    console.log('start saving')
+    const addedWithDigiroadLinks = await timer("addedWithDigiroadLinks",  async () => {
+        return await assetHandler.filterRoadLinks(addedWithLinks)
+    })
+    
+    const updatedWithDigiroadLinks =await  timer("updatedWithDigiroadLinks ", async () => {
+        return await assetHandler.filterRoadLinks(updatedWithLinks)
+    })
+    //await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
+   // await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
 }

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -3,7 +3,7 @@ import { Client, ClientConfig } from 'pg';
 import { Agent, setGlobalDispatcher } from 'undici';
 import { PointAssetHandler } from "./pointAssetHandler";
 import { LinearAssetHandler } from "./linearAssetHandler";
-import { VelhoAsset } from "./assetHandler";
+import { PavementHandler } from "./pavementHandler";
 
 const agent = new Agent({
     connect: {
@@ -46,37 +46,6 @@ const authenticate = async () => {
     return data.access_token
 }
 
-const listKohdeluokka = async (token: string, target: string): Promise<{ [key: string]: string }> => {
-    const baseUrl = await getVelhoBaseUrl()
-    const response = await fetch(`${baseUrl}/${target}`, {
-        method: 'GET',
-        headers: {
-            'Authorization': 'Bearer ' + token,
-        },
-    });
-
-    if (!response.ok) {
-        throw new Error(`HTTP error in list kohdeluokka! Status: ${response.status}`);
-    }
-
-    interface Kohdeluokka {
-        jaottelut: {
-            "alueet/ely": {
-                [ely: string]: {
-                    polku: string
-                }
-            }
-        }
-    }
-
-    const data = await response.json() as Kohdeluokka
-    return Object.keys(data.jaottelut["alueet/ely"]).reduce((acc: any, val: string) => {
-        const ely = val.replace('ely/ely', '')
-        acc[ely] = data.jaottelut["alueet/ely"][val].polku
-        return acc
-    }, {})
-}
-
 const fetchMunicipalities = async (ely: string): Promise<number[]> => {
     const client = await getClient()
     try {
@@ -96,20 +65,31 @@ const fetchMunicipalities = async (ely: string): Promise<number[]> => {
     throw '500: something weird happened'
 }
 
-export const handler = async (event: { ely: string, asset_name: string, asset_type_id: number, asset_type: string, path: string }, ctx: any) => {
+const getAssetHandler = (asset_type_id: number, asset_type: string) => {
+    if (asset_type_id === 110) {
+        return new PavementHandler
+    } else if (asset_type === 'Point') {
+        return new PointAssetHandler
+    } else {
+        return new LinearAssetHandler
+    }
+}
+
+export const handler = async (event: { ely: string, asset_name: string, asset_type_id: number, asset_type: string, paths: string[] }, ctx: any) => {
     console.log(`Event: ${JSON.stringify(event, null, 2)}`);
 
-    const { ely, asset_name, asset_type_id, asset_type, path } = event;
-    const assetHandler = asset_type === 'Point' ? new PointAssetHandler : new LinearAssetHandler
+    const { ely, asset_name, asset_type_id, asset_type, paths } = event;
+    const assetHandler = getAssetHandler(asset_type_id, asset_type)
     const vkmApiKey = await getVkmApiKey()
     if (!vkmApiKey) throw new Error("vkm api key is not defined")
     const authToken = await authenticate()
-    const ely2polku = await listKohdeluokka(authToken, `kohdeluokka/${path}`)
-    if (!ely2polku[ely]) throw new Error("no path found for ely")
-    const srcData = await assetHandler.fetchSourceData(authToken, ely2polku[ely]) as VelhoAsset[]
+    const srcData = await assetHandler.fetchSource(authToken, ely, paths)
     console.log(`fetched ${srcData.length} assets from velho`)
     const filteredSrc = assetHandler.filterUnnecessary(srcData)
-    if (filteredSrc.length === 0) return
+    if (filteredSrc.length === 0) {
+        console.log('No assets to process after filtering.')
+        return
+    }
     const municipalities = await fetchMunicipalities(ely)
     console.log(`municipalities to process: ${municipalities.join(',')}`)
     const currentData = await assetHandler.fetchDestData(asset_type_id, municipalities)

--- a/velho-integration/src/lambda/fetchAndProcess.ts
+++ b/velho-integration/src/lambda/fetchAndProcess.ts
@@ -106,5 +106,5 @@ export const handler = async (event: { ely: string, asset_name: string, asset_ty
     const addedWithDigiroadLinks = await assetHandler.filterRoadLinks(addedWithLinks)
     await assetHandler.saveNewAssets(asset_type_id, addedWithDigiroadLinks)
     const updatedWithDigiroadLinks = await assetHandler.filterRoadLinks(updatedWithLinks)
-    await assetHandler.updateAssets(updatedWithDigiroadLinks)
+    await assetHandler.updateAssets(asset_type_id, updatedWithDigiroadLinks)
 }

--- a/velho-integration/src/lambda/linearAssetHandler.ts
+++ b/velho-integration/src/lambda/linearAssetHandler.ts
@@ -1,5 +1,5 @@
 import { getClient } from "./fetchAndProcess";
-import { AssetHandler, VelhoAsset, DbAsset, AssetWithLinkData} from "./assetHandler";
+import { AssetHandler, VelhoAsset, DbAsset, AssetWithLinkData } from "./assetHandler";
 import { VelhoLinearAsset } from "./assetHandler";
 import { retryTimeout } from "./utils";
 
@@ -144,7 +144,7 @@ export class LinearAssetHandler extends AssetHandler {
                         mValueEnd: link.m_arvo_loppu,
                         municipalityCode: link.kuntakoodi
                     }));
-            
+
                 return {
                     asset: asset,
                     linkData: matchedLinkData

--- a/velho-integration/src/lambda/linearAssetHandler.ts
+++ b/velho-integration/src/lambda/linearAssetHandler.ts
@@ -304,8 +304,7 @@ export class LinearAssetHandler extends AssetHandler {
         }
     };
 
-    //TODO implement update for linears when there are asset types to update
-    updateAssets = async (assetsToUpdate: AssetWithLinkData[]) => {
+    override async updateAssets(asset_type_id: number, assetsToUpdate: AssetWithLinkData[]) {
         return
     }
 }

--- a/velho-integration/src/lambda/linearAssetHandler.ts
+++ b/velho-integration/src/lambda/linearAssetHandler.ts
@@ -127,7 +127,7 @@ export class LinearAssetHandler extends AssetHandler {
                     tunniste: c.tunniste, palautusarvot: '4,6', valihaku: "true"
                 }));
                 const encodedBody = encodeURIComponent(JSON.stringify(locationAndReturnValue));
-                const data = await retryTimeout(async () => await this.fetchVKM(encodedBody,vkmApiKey), 5, 5000);
+                const data = await retryTimeout(async () => await this.fetchVKM(encodedBody,vkmApiKey), 10, 5000);
 
                 return data.features
                     .filter(f => this.isValidVKMFeature(f))
@@ -164,7 +164,7 @@ export class LinearAssetHandler extends AssetHandler {
                     valihaku: true
                 }));
                 const encodedBody = encodeURIComponent(JSON.stringify(locationAndReturnValue));
-                const data = await retryTimeout(async () => await this.fetchVKM(encodedBody,vkmApiKey), 5, 5000);
+                const data = await retryTimeout(async () => await this.fetchVKM(encodedBody,vkmApiKey), 10, 5000);
                 return data.features
                     .filter(f => this.isValidVKMFeature(f))
                     .map(f => {

--- a/velho-integration/src/lambda/pavementHandler.ts
+++ b/velho-integration/src/lambda/pavementHandler.ts
@@ -1,4 +1,4 @@
-import { VelhoAsset } from "./assetHandler";
+import { VelhoAsset, VelhoLinearAsset } from "./assetHandler";
 import { LinearAssetHandler } from "./linearAssetHandler";
 
 enum PavementClass {
@@ -101,10 +101,10 @@ export class PavementHandler extends LinearAssetHandler {
      * @param asset_name asset_name as defined in lambda
      * @returns 
      */
-    override filterUnnecessary(srcData: VelhoAsset[]): VelhoAsset[] {
+    override filterUnnecessary(srcData: VelhoLinearAsset[]): VelhoLinearAsset[] {
         const mainLanes = ['kaista-numerointi/kanu11', 'kaista-numerointi/kanu21', 'kaista-numerointi/kanu31']
         const mainLanesFromOneSide = ['kaista-numerointi/kanu11', 'kaista-numerointi/kanu31']
-        const srcWithValidStatus = super.filterUnnecessary(srcData);
+        const srcWithValidStatus = super.filterUnnecessary(srcData) as VelhoLinearAsset[];
         const necessaryAssets = srcWithValidStatus.filter(s => {
             if (s.sijaintitarkenne.ajoradat && s.sijaintitarkenne.ajoradat.length === 1 && s.sijaintitarkenne.ajoradat[0] === 'ajorata/ajr0') {
                 return !s.sijaintitarkenne.kaistat || s.sijaintitarkenne.kaistat.length === 0 || s.sijaintitarkenne.kaistat.some(lane => mainLanesFromOneSide.includes(lane))

--- a/velho-integration/src/lambda/pavementHandler.ts
+++ b/velho-integration/src/lambda/pavementHandler.ts
@@ -1,17 +1,28 @@
 import { VelhoAsset } from "./assetHandler";
 import { LinearAssetHandler } from "./linearAssetHandler";
 
+enum PavementClass {
+    Asphalt = 1, //asfaltti
+    Cobblestone = 2, //kivi
+    UnboundWearLayer = 3, //sitomaton kulutuskerros
+    OtherPavementClasses = 4, //muut päällysteluokat
+    Unknown = 99 //päällystetty, tyyppi tuntematon
+}
+
 export class PavementHandler extends LinearAssetHandler {
 
-    // the original source path of each pavement is necessary for correct mappings and filterings
-    private pathByOid: { [oid: string]: string } = {};
+    // the original velho source of each pavement is necessary for correct mappings and filterings
+    private sourceByOid: { [oid: string]: string } = {};
+
+    // pavements mapped by oid to digiroad pavement types
+    private pavementByOid: { [oid: string]: PavementClass } = {}
 
     override fetchSource = async (token: string, ely: string, paths: string[]): Promise<VelhoAsset[]> => {
         const allVelhoAssets = await Promise.all(
             paths.map(async (path) => {
                 const srcData: VelhoAsset[] = await this.fetchSourceFromPath(token, ely, path);
                 srcData.forEach((s) => {
-                    this.pathByOid[s.oid] = path;
+                    this.sourceByOid[s.oid] = path.replace('paallyste-ja-pintarakenne/', '');
                 });
                 return srcData;
             })
@@ -20,7 +31,65 @@ export class PavementHandler extends LinearAssetHandler {
     }
 
     private filterByPavementType = (srcData: VelhoAsset[]): VelhoAsset[] => {
-        return []
+        const asphaltSources = ['muu-materiaali/mm04', 'paallystetyyppi/pt01', 'paallystetyyppi/pt02', 'paallystetyyppi/pt03', 'paallystetyyppi/pt04',
+            'paallystetyyppi/pt08', 'paallystetyyppi/pt09', 'paallystetyyppi/pt10', 'paallystetyyppi/pt11', 'paallystetyyppi/pt12', 'paallystetyyppi/pt13',
+            'paallystetyyppi/pt14', 'paallystetyyppi/pt15', 'paallystetyyppi/pt16', 'paallystetyyppi/pt17', 'paallystetyyppi/pt18'
+        ]
+        const cobblestoneSources = ['kiven-materiaali/km01', 'kiven-materiaali/km02', 'kiven-materiaali/km03']
+        const unboundSources = ['muu-materiaali/mm03', 'muu-materiaali/mm09', 'sitomattoman-pintarakenteen-runkomateriaali/spr01',
+            'sitomattoman-pintarakenteen-runkomateriaali/spr02', 'sitomattoman-pintarakenteen-runkomateriaali/spr03']
+        const otherSources = ['muu-materiaali/mm01', 'muu-materiaali/mm02', 'muu-materiaali/mm05', 'muu-materiaali/mm06', 'muu-materiaali/mm07',
+            'pintauksen-tyyppi/pintaus01', 'pintauksen-tyyppi/pintaus03', 'pintauksen-uusiomateriaali/pu', 'paallystetyyppi/pt07'
+        ]
+        const unknownTypeSources = ['muu-materiaali/mm08', 'paallystetyyppi/pt21']
+        srcData.forEach(s => {
+            const velhoSource = this.sourceByOid[s.oid]
+            switch (velhoSource) {
+                case 'ladottavat-pintarakenteet':
+                    if (s.ominaisuudet?.materiaali && cobblestoneSources.includes(s.ominaisuudet.materiaali)) {
+                        this.pavementByOid[s.oid] = PavementClass.Cobblestone
+                    }
+                    break
+                case 'muut-pintarakenteet':
+                    if (s.ominaisuudet?.materiaali) {
+                        if (asphaltSources.includes(s.ominaisuudet.materiaali)) {
+                            this.pavementByOid[s.oid] = PavementClass.Asphalt
+                        } else if (unboundSources.includes(s.ominaisuudet.materiaali)) {
+                            this.pavementByOid[s.oid] = PavementClass.UnboundWearLayer
+                        } else if (otherSources.includes(s.ominaisuudet.materiaali)) {
+                            this.pavementByOid[s.oid] = PavementClass.OtherPavementClasses
+                        } else if (unknownTypeSources.includes(s.ominaisuudet.materiaali)) {
+                            this.pavementByOid[s.oid] = PavementClass.Unknown
+                        }
+                    }
+                    break
+                case 'pintaukset':
+                    if (s.ominaisuudet?.['pintauksen-tyyppi'] && otherSources.includes(s.ominaisuudet['pintauksen-tyyppi'])) {
+                        this.pavementByOid[s.oid] = PavementClass.Unknown
+                    } else if (s.ominaisuudet?.uusiomateriaali && otherSources.includes(s.ominaisuudet?.uusiomateriaali)) {
+                        this.pavementByOid[s.oid] = PavementClass.Unknown
+                    }
+                    break
+                case 'sidotut-paallysrakenteet':
+                    if (s.ominaisuudet?.tyyppi && s.ominaisuudet['paallysteen-tyyppi'] && s.ominaisuudet.tyyppi === 'sidotun-paallysrakenteen-tyyppi/spt01') {
+                        if (asphaltSources.includes(s.ominaisuudet['paallysteen-tyyppi'])) {
+                            this.pavementByOid[s.oid] = PavementClass.Asphalt
+                        } else if (otherSources.includes(s.ominaisuudet['paallysteen-tyyppi'])) {
+                            this.pavementByOid[s.oid] = PavementClass.OtherPavementClasses
+                        } else if (unknownTypeSources.includes(s.ominaisuudet['paallysteen-tyyppi'])) {
+                            PavementClass.Unknown
+                        }
+                    }
+                case 'sitomattomat-pintarakenteet':
+                    if (s.ominaisuudet?.runkomateriaali && unboundSources.includes(s.ominaisuudet.runkomateriaali)) {
+                        this.pavementByOid[s.oid] = PavementClass.UnboundWearLayer
+                    }
+                default:
+                    throw new Error('unrecognized pavement source')
+            }
+        })
+
+        return srcData.filter(s => Object.keys(this.pavementByOid).includes(s.oid))
     }
 
     /**

--- a/velho-integration/src/lambda/pavementHandler.ts
+++ b/velho-integration/src/lambda/pavementHandler.ts
@@ -1,0 +1,48 @@
+import { VelhoAsset } from "./assetHandler";
+import { LinearAssetHandler } from "./linearAssetHandler";
+
+export class PavementHandler extends LinearAssetHandler {
+
+    // the original source path of each pavement is necessary for correct mappings and filterings
+    private pathByOid: { [oid: string]: string } = {};
+
+    override fetchSource = async (token: string, ely: string, paths: string[]): Promise<VelhoAsset[]> => {
+        const allVelhoAssets = await Promise.all(
+            paths.map(async (path) => {
+                const srcData: VelhoAsset[] = await this.fetchSourceFromPath(token, ely, path);
+                srcData.forEach((s) => {
+                    this.pathByOid[s.oid] = path;
+                });
+                return srcData;
+            })
+        );
+        return allVelhoAssets.flat();
+    }
+
+    private filterByPavementType = (srcData: VelhoAsset[]): VelhoAsset[] => {
+        return []
+    }
+
+    /**
+     * This method performs first the parent class filter. Then it filters the velho assets on main lanes. 
+     * If the roadway has lanes to both directions the other side lane (kanu21) is discarded to avoid duplicates
+     * as it's expected that the pavement is the same to both directions. Moreover, this method filters out 
+     * the pavement types not imported to Digiroad
+     * @param srcData all velho assets for ely
+     * @param asset_name asset_name as defined in lambda
+     * @returns 
+     */
+    override filterUnnecessary(srcData: VelhoAsset[]): VelhoAsset[] {
+        const mainLanes = ['kaista-numerointi/kanu11', 'kaista-numerointi/kanu21', 'kaista-numerointi/kanu31']
+        const mainLanesFromOneSide = ['kaista-numerointi/kanu11', 'kaista-numerointi/kanu31']
+        const srcWithValidStatus = super.filterUnnecessary(srcData);
+        const necessaryAssets = srcWithValidStatus.filter(s => {
+            if (s.sijaintitarkenne.ajoradat && s.sijaintitarkenne.ajoradat.length === 1 && s.sijaintitarkenne.ajoradat[0] === 'ajorata/ajr0') {
+                return !s.sijaintitarkenne.kaistat || s.sijaintitarkenne.kaistat.length === 0 || s.sijaintitarkenne.kaistat.some(lane => mainLanesFromOneSide.includes(lane))
+            } else {
+                return !s.sijaintitarkenne.kaistat || s.sijaintitarkenne.kaistat.length === 0 || s.sijaintitarkenne.kaistat.some(lane => mainLanes.includes(lane))
+            }
+        })
+        return this.filterByPavementType(necessaryAssets)
+    };
+}

--- a/velho-integration/src/lambda/pointAssetHandler.ts
+++ b/velho-integration/src/lambda/pointAssetHandler.ts
@@ -144,10 +144,10 @@ export class PointAssetHandler extends AssetHandler {
             if (missingLinks.length > 0) {
                 console.log('Missing links in db:', missingLinks.join(','));
             }
-            return assetsWithLinkData.filter(s => 
+            return assetsWithLinkData.filter(s =>
                 s.linkData?.[0]?.linkId !== undefined && linkIds.some(linkid => s.linkData?.[0]?.linkId === linkid)
             );
-            
+
         } catch (err) {
             console.log('error during road link filtering', err)
         } finally {
@@ -211,7 +211,7 @@ export class PointAssetHandler extends AssetHandler {
         }
     };
 
-    override async updateAssets(assetsToUpdate: AssetWithLinkData[]) {
+    override async updateAssets(asset_type_id: number, assetsToUpdate: AssetWithLinkData[]) {
 
         if (this.updateAssets.length === 0) {
             console.log("No assets to update.")
@@ -244,13 +244,13 @@ export class PointAssetHandler extends AssetHandler {
                 );
             `;
 
-            await client.query(updateSql, [
-                assetWithLinkData.linkData?.[0]?.municipalityCode,
-                assetWithLinkData.asset.oid,
-                assetWithLinkData.linkData?.[0]?.mValue,
-                assetWithLinkData.linkData?.[0]?.linkId,
-                timeStamp
-            ]);
+                await client.query(updateSql, [
+                    assetWithLinkData.linkData?.[0]?.municipalityCode,
+                    assetWithLinkData.asset.oid,
+                    assetWithLinkData.linkData?.[0]?.mValue,
+                    assetWithLinkData.linkData?.[0]?.linkId,
+                    timeStamp
+                ]);
             });
 
             await Promise.all(updatePromises);

--- a/velho-integration/src/lambda/trafficSignHandler.ts
+++ b/velho-integration/src/lambda/trafficSignHandler.ts
@@ -1,0 +1,57 @@
+import { PointAssetHandler } from './pointAssetHandler';
+import { VelhoAsset } from "./assetHandler";
+import { Track, VelhoRoadSide, SideCode, VelhoValidityDirection, ValidityDirectionRoadAddress } from './enumerations';
+
+
+export interface VelhoTrafficSignAsset extends VelhoAsset {
+    
+};
+
+export class TrafficSignHandler extends PointAssetHandler {
+
+    calculateTrafficSignValidityDirection(roadAddressSideCode: SideCode, velhoAssetRoadSide: VelhoRoadSide,
+        velhoAssetValidityDirection: VelhoValidityDirection): SideCode {
+
+           let validityDirectionRoadAddressGrowth: ValidityDirectionRoadAddress;
+
+           // Determine the validity direction in relation to road address growth
+            switch(velhoAssetRoadSide) {
+               case VelhoRoadSide.Right:
+                   if(velhoAssetValidityDirection == VelhoValidityDirection.TowardsTrafficDirection) {
+                       validityDirectionRoadAddressGrowth = ValidityDirectionRoadAddress.TowardsRoadAddressGrowth;
+                   } else if(velhoAssetValidityDirection == VelhoValidityDirection.AgainstTrafficDirection) {
+                       validityDirectionRoadAddressGrowth =  ValidityDirectionRoadAddress.AgainstRoadAddressGrowth;
+                   }
+               case VelhoRoadSide.Left:
+                   if(velhoAssetValidityDirection == VelhoValidityDirection.TowardsTrafficDirection) {
+                       validityDirectionRoadAddressGrowth =  ValidityDirectionRoadAddress.AgainstRoadAddressGrowth;
+                   } else if(velhoAssetValidityDirection == VelhoValidityDirection.AgainstTrafficDirection) {
+                       validityDirectionRoadAddressGrowth =  ValidityDirectionRoadAddress.TowardsRoadAddressGrowth;
+                   }
+                   //Placeholder default handling
+               default:
+                   validityDirectionRoadAddressGrowth = ValidityDirectionRoadAddress.TowardsRoadAddressGrowth
+           }
+
+           // Use road address side code to determine the validity direction in relation to digitizing direction
+           switch(roadAddressSideCode) {
+               case SideCode.AgainstDigitizing:
+                   if(validityDirectionRoadAddressGrowth == ValidityDirectionRoadAddress.TowardsRoadAddressGrowth) {
+                       return SideCode.AgainstDigitizing;
+                   } else if (validityDirectionRoadAddressGrowth == ValidityDirectionRoadAddress.AgainstRoadAddressGrowth) {
+                       return SideCode.TowardsDigitizing;
+                   }
+               case SideCode.TowardsDigitizing:
+                   if(validityDirectionRoadAddressGrowth == ValidityDirectionRoadAddress.TowardsRoadAddressGrowth) {
+                       return SideCode.TowardsDigitizing;
+                   } else if (validityDirectionRoadAddressGrowth == ValidityDirectionRoadAddress.AgainstRoadAddressGrowth) {
+                       return SideCode.AgainstDigitizing;
+                   }
+                   //Placeholder default handling
+               default:
+                   return SideCode.TowardsDigitizing;
+           }
+  }
+}
+    
+

--- a/velho-integration/src/lambda/utils.ts
+++ b/velho-integration/src/lambda/utils.ts
@@ -11,7 +11,6 @@ export const retry = async <T>(
         return Promise.reject(err);
     }
     return fn().catch((err: Error) => {
-        console.log('err', err);
         if (!retryIfTest || retryIfTest(err)) {
             console.log(`Retries left: ${retries}`);
             return delay(delayTimeMs).then(() => retry(fn, retryIfTest, retries - 1, delayTimeMs, err));

--- a/velho-integration/src/lambda/utils.ts
+++ b/velho-integration/src/lambda/utils.ts
@@ -27,3 +27,11 @@ export const retryTimeout = async <T>(fn: () => Promise<T>, retries = 3, delayTi
     }
     return retry(fn, timeoutTest, retries, delayTimeMs);
 };
+
+export const timer = <R>(operationName: string, operation: () => R): R => {
+    const begin = performance.now();
+    const result = operation();
+    const duration = performance.now() - begin;
+    console.log(`Call to ${operationName} took: ${(duration / 1000).toFixed(4)} s.`);
+    return result;
+};

--- a/velho-integration/src/lambda/utils.ts
+++ b/velho-integration/src/lambda/utils.ts
@@ -22,16 +22,34 @@ export const retry = async <T>(
 
 export const retryTimeout = async <T>(fn: () => Promise<T>, retries = 3, delayTimeMs = 5000): Promise<T> => {
     const timeoutTest = (err: Error) => {
+        console.log(err)
         if ('code' in err) return (err as unknown as { code: string }).code === 'ETIMEDOUT'
-        return err.message.includes('network timeout');
+        
+        return err.message.includes('network timeout') || err.message.includes('Gateway Time-out');
     }
     return retry(fn, timeoutTest, retries, delayTimeMs);
 };
-
+// When using in promise, you should be mindfull what you are measuring, are you measuring resolving of promise or actual operation.
+// Best to use in non async method.
 export const timer = <R>(operationName: string, operation: () => R): R => {
     const begin = performance.now();
-    const result = operation();
-    const duration = performance.now() - begin;
-    console.log(`Call to ${operationName} took: ${(duration / 1000).toFixed(4)} s.`);
-    return result;
+    try {
+        const result = operation();
+        const duration = performance.now() - begin;
+        console.log(`Call to ${operationName} took: ${(duration / 1000).toFixed(4)} s.`);
+        return result;
+    } catch (e: any) {
+        const duration = performance.now() - begin;
+        console.log(`Call to ${operationName} failed at ${(duration / 1000).toFixed(4)} s.`,e);
+        throw e;
+    }
+    
+};
+
+export const chunkData = <T>(array: T[], chunkSize: number): T[][] => {
+    const R: T[][] = [];
+    for (let i = 0, len = array.length; i < len; i += chunkSize) {
+        R.push(array.slice(i, i + chunkSize));
+    }
+    return R;
 };

--- a/velho-integration/test/pavement.test.ts
+++ b/velho-integration/test/pavement.test.ts
@@ -1,0 +1,380 @@
+import { PavementHandler, VelhoPavementAsset, PavementClass } from "../src/lambda/pavementHandler";
+
+const assetHandler = new PavementHandler();
+
+describe('filter by lanes and roadways', () => {
+
+    const oids = ['1', '2', '3', '4', '5', '6'];
+    assetHandler.sourceByOid = Object.fromEntries(oids.map(oid => [oid, 'muut-pintarakenteet']));
+
+    test('roadway 0, lanes not specified: asset should be included', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's1',
+                sijaintitarkenne: { ajoradat: ['ajorata/ajr0'], kaistat: [] },
+                oid: '1',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(1);
+        expect(result[0].oid).toBe('1');
+    });
+
+    test('roadway 0, main lane 11: asset should be included', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's2',
+                sijaintitarkenne: { ajoradat: ['ajorata/ajr0'], kaistat: ['kaista-numerointi/kanu11'] },
+                oid: '2',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(1);
+        expect(result[0].oid).toBe('2');
+    });
+
+    test('roadway 0, main lane 21: asset should be discarded as redundant', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's3',
+                sijaintitarkenne: { ajoradat: ['ajorata/ajr0'], kaistat: ['kaista-numerointi/kanu21'] },
+                oid: '3',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(0);
+    });
+
+    test('roadway 1, sublane 12: asset should be discarded', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's4',
+                sijaintitarkenne: { ajoradat: ['ajorata/ajr1'], kaistat: ['kaista-numerointi/kanu12'] },
+                oid: '4',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(0);
+    });
+
+    test('no roadway specified, main lane 11: asset should be included', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's5',
+                sijaintitarkenne: { ajoradat: [], kaistat: ['kaista-numerointi/kanu11'] },
+                oid: '5',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(1);
+        expect(result[0].oid).toBe('5');
+    });
+
+    test('roadway 0, asset in both main lanes: asset should be included', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's6',
+                sijaintitarkenne: { ajoradat: ['ajorata/ajr0'], kaistat: ['kaista-numerointi/kanu11', 'kaista-numerointi/kanu21'] },
+                oid: '6',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+
+        const result = assetHandler.filterUnnecessary(srcData);
+        expect(result).toHaveLength(1);
+        expect(result[0].oid).toBe('6');
+    })
+});
+
+describe('filter by pavement type', () => {
+    test('filters asphalt types correctly', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's1',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '1',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            },
+            {
+                'sijainti-oid': 's2',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '2',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt10' }
+            }
+        ];
+        assetHandler.sourceByOid = { '1': 'muut-pintarakenteet', '2': 'sidotut-paallysrakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.Asphalt, PavementClass.Asphalt,
+        ]);
+    });
+
+    test('filters cobblestone types correctly', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's3',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '3',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': 'tt03',
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { materiaali: 'kiven-materiaali/km01' }
+            },
+            {
+                'sijainti-oid': 's4',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '4',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { materiaali: 'kiven-materiaali/km02' }
+            }
+        ];
+        assetHandler.sourceByOid = { '3': 'ladottavat-pintarakenteet', '4': 'ladottavat-pintarakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.Cobblestone, PavementClass.Cobblestone,
+        ]);
+    });
+
+    test('filters unbound pavement types correctly', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's5',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '5',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm09' }
+            },
+            {
+                'sijainti-oid': 's6',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '6',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { runkomateriaali: 'sitomattoman-pintarakenteen-runkomateriaali/spr03' }
+            }
+        ];
+        assetHandler.sourceByOid = { '5': 'muut-pintarakenteet', '6': 'sitomattomat-pintarakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.UnboundWearLayer, PavementClass.UnboundWearLayer,
+        ]);
+    });
+
+    test('filters other pavement types correctly', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's7',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '7',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm01' }
+            },
+            {
+                'sijainti-oid': 's8',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '8',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt07' }
+            }
+        ];
+        assetHandler.sourceByOid = { '7': 'muut-pintarakenteet', '8': 'sidotut-paallysrakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.OtherPavementClasses, PavementClass.OtherPavementClasses,
+        ]);
+    });
+
+    test('filters unknown pavement types correctly', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's9',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '9',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm08' }
+            },
+            {
+                'sijainti-oid': 's10',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '10',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt21' }
+            }
+        ];
+        assetHandler.sourceByOid = { '9': 'muut-pintarakenteet', '10': 'sidotut-paallysrakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.Unknown, PavementClass.Unknown,
+        ]);
+    });
+
+    test('throws exception on an unrecognized source', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's11',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '11',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { materiaali: 'muu-materiaali/mm04' }
+            }
+        ];
+        assetHandler.sourceByOid = { '11': 'unknown-source' };
+        expect(() => assetHandler.filterByPavementType(srcData)).toThrow('unrecognized pavement source');
+    });
+
+    test('surfacing 1 is taken, but 2 is ignored', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's12',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '12',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { 'pintauksen-tyyppi': 'pintauksen-tyyppi/pintaus01' }
+            },
+            {
+                'sijainti-oid': 's13',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '13',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: 'MultiLinestring' },
+                ominaisuudet: { 'pintauksen-tyyppi': 'pintauksen-tyyppi/pintaus02' }
+            }
+        ];
+        assetHandler.sourceByOid = { '12': 'pintaukset', '13': 'pintaukset' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => r.oid)).toEqual(['12'])
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.OtherPavementClasses,
+        ]);
+    });
+
+    test('if bound surface type material is something else than 1, the asset is ignored', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's14',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '14',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt02', 'paallysteen-tyyppi': 'paallystetyyppi/pt21' }
+            },
+            {
+                'sijainti-oid': 's15',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '15',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt21' }
+            }
+        ];
+        assetHandler.sourceByOid = { '14': 'sidotut-paallysrakenteet', '15': 'sidotut-paallysrakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.map(r => r.oid)).toEqual(['15'])
+        expect(result.map(r => assetHandler.pavementByOid[r.oid])).toEqual([
+            PavementClass.Unknown,
+        ]);
+    });
+
+    test('materials not listed are ignored', () => {
+        const srcData: VelhoPavementAsset[] = [
+            {
+                'sijainti-oid': 's16',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '16',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt05' }
+            },
+            {
+                'sijainti-oid': 's17',
+                sijaintitarkenne: { ajoradat: [''] },
+                oid: '17',
+                luotu: '2023-01-01T12:00:00Z',
+                muokattu: '2023-02-01T12:00:00Z',
+                'tiekohteen-tila': null,
+                keskilinjageometria: { coordinates: [[[0, 0, 0]]], type: "MultiLinestring" },
+                ominaisuudet: { tyyppi: 'sidotun-paallysrakenteen-tyyppi/spt01', 'paallysteen-tyyppi': 'paallystetyyppi/pt06' }
+            }
+        ];
+        assetHandler.sourceByOid = { '16': 'sidotut-paallysrakenteet', '17': 'sidotut-paallysrakenteet' };
+        const result = assetHandler.filterByPavementType(srcData);
+        expect(result.length === 0)
+    });
+});

--- a/velho-integration/test/trafficSign.test.ts
+++ b/velho-integration/test/trafficSign.test.ts
@@ -1,0 +1,31 @@
+import { Track, VelhoRoadSide, SideCode, VelhoValidityDirection} from '../src/lambda/enumerations';
+import { TrafficSignHandler } from '../src/lambda/trafficSignHandler';
+
+const assetHandler = new TrafficSignHandler
+
+test("Right side with validity direction towards traffic should return AgainstDigitizing", () => {
+    const result = assetHandler.calculateTrafficSignValidityDirection(
+        SideCode.AgainstDigitizing,
+        VelhoRoadSide.Right,
+        VelhoValidityDirection.TowardsTrafficDirection
+    );
+    expect(result).toBe(SideCode.AgainstDigitizing);
+  });
+  
+  test("Right side with validity direction against traffic should return TowardsDigitizing", () => {
+    const result = assetHandler.calculateTrafficSignValidityDirection(
+        SideCode.AgainstDigitizing,
+        VelhoRoadSide.Right,
+        VelhoValidityDirection.AgainstTrafficDirection
+    );
+    expect(result).toBe(SideCode.AgainstDigitizing);
+  });
+  
+  test("Left side with validity direction towards traffic should return TowardsDigitizing", () => {
+    const result = assetHandler.calculateTrafficSignValidityDirection(
+        SideCode.AgainstDigitizing,
+        VelhoRoadSide.Left,
+        VelhoValidityDirection.TowardsTrafficDirection
+    );
+    expect(result).toBe(SideCode.AgainstDigitizing);
+  });

--- a/velho-integration/test/velho-integration.test.ts
+++ b/velho-integration/test/velho-integration.test.ts
@@ -1,8 +1,9 @@
-import { VelhoAsset } from '../src/lambda/assetHandler';
+import { VelhoAsset, VelhoPointAsset } from '../src/lambda/assetHandler';
 import { PointAssetHandler } from '../src/lambda/pointAssetHandler';
 import { DbAsset } from '../src/lambda/assetHandler';
+import { Track, VelhoRoadSide, SideCode, VelhoValidityDirection} from '../src/lambda/enumerations';
 
-const srcData: VelhoAsset[] = [
+const srcData: VelhoPointAsset[] = [
   {
     sijainti: {
       osa: 1,
@@ -224,5 +225,4 @@ test('calculateDiff sorts as notTouched if a db asset has a later created modifi
   const result = assetHandler.calculateDiff(filteredSrc, currentData);
   expect(result.notTouched.map(r => r.externalId)).toEqual(['oid6', 'oid7']);
 });
-
 

--- a/velho-integration/test/velho-integration.test.ts
+++ b/velho-integration/test/velho-integration.test.ts
@@ -196,27 +196,32 @@ const currentData: DbAsset[] = [
 const assetHandler = new PointAssetHandler
 
 test('calculateDiff sorts as added only assets with valid tiekohteen-tila, no previous assets in db', () => {
-  const result = assetHandler.calculateDiff(srcData, []);
+  const filteredSrc = assetHandler.filterUnnecessary(srcData)
+  const result = assetHandler.calculateDiff(filteredSrc, []);
   expect(result.added.map(r => r.oid)).toEqual(['oid1', 'oid2', 'oid5', 'oid6', 'oid7']);
 });
 
 test('calculateDiff sorts as added only assets not present in db', () => {
-  const result = assetHandler.calculateDiff(srcData, currentData);
+  const filteredSrc = assetHandler.filterUnnecessary(srcData)
+  const result = assetHandler.calculateDiff(filteredSrc, currentData);
   expect(result.added.map(r => r.oid)).toEqual(['oid2']);
 });
 
 test('calculateDiff sorts as expired if an asset is not in srcData or has invalid tiekohteen-tila', () => {
-  const result = assetHandler.calculateDiff(srcData, currentData);
+  const filteredSrc = assetHandler.filterUnnecessary(srcData)
+  const result = assetHandler.calculateDiff(filteredSrc, currentData);
   expect(result.expired.map(r => r.externalId)).toEqual(['oid3', 'oid4']);
 });
 
 test('calculateDiff sorts as updated if a src asset has a later modified date than created or modified date of a db asset', () => {
-  const result = assetHandler.calculateDiff(srcData, currentData);
+  const filteredSrc = assetHandler.filterUnnecessary(srcData)
+  const result = assetHandler.calculateDiff(filteredSrc, currentData);
   expect(result.updated.map(r => r.oid)).toEqual(['oid1', 'oid5']);
 });
 
 test('calculateDiff sorts as notTouched if a db asset has a later created modified date than the modified date of a src asset', () => {
-  const result = assetHandler.calculateDiff(srcData, currentData);
+  const filteredSrc = assetHandler.filterUnnecessary(srcData)
+  const result = assetHandler.calculateDiff(filteredSrc, currentData);
   expect(result.notTouched.map(r => r.externalId)).toEqual(['oid6', 'oid7']);
 });
 


### PR DESCRIPTION
Päällysteiden velho-integraatio + osia liikennemerkkien integraatiosta, koska rakennetta kehitetty yhdessä.

 VKM-haun ongelmat tulee ratkaista ennen mergeä, tarkempi kuvaus tiketissä.
Itse VKM puute viellä korjaamatta VKM päässä. Performanssi ongelma ratkottu korjaamalla retry metodi ja käyttämällä indeksiä. Retry on nostettu 10 ajatuksena että ensimmäinen ajo lämmittelee VKM nostamaan lisää konteja ylös. Kontien nostoon menee useita sekunteeja joten pitää sallia hitaus ensimmäiseksä ajossa.
Itse tallennus pitäisi olla kohtuu nopea operaatio.

https://github.com/finnishtransportagency/digiroad-batch/pull/19